### PR TITLE
XDG_SHARE_HOME not found in the XDG Base Spec

### DIFF
--- a/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
+++ b/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
@@ -50,7 +50,7 @@ sections:
       description: Temporary directory for scripts
     sourceDir:
       default: >-
-        `$XDG_SHARE_HOME/chezmoi` <br/>
+        `$XDG_DATA_HOME/chezmoi` <br/>
         `$HOME/.local/share/chezmoi` <br/>
         `%USERPROFILE%/.local/share/chezmoi`
       description: Source directory


### PR DESCRIPTION
Possibly `XDG_DATA_HOME` is intended